### PR TITLE
Updating CNI image

### DIFF
--- a/eks-worker-al2.json
+++ b/eks-worker-al2.json
@@ -15,7 +15,7 @@
     "kubernetes_version": null,
     "kubernetes_build_date": null,
     "docker_version": "19.03.6ce-4.amzn2",
-    "cni_version": "v0.6.0",
+    "cni_version": "v0.6.3",
     "cni_plugin_version": "v0.7.5",
     "og_image_version": "1.2.0",
     "ami_regions": "us-west-2,us-east-1",


### PR DESCRIPTION
0.6.0 image is failing for reason
```
starting IPAM daemon in background ... ok.
checking for IPAM connectivity ...  failed.
timed out waiting for IPAM daemon to start.
```

0.6.3 has a fix for this error

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
