### PR TITLE
[CLOUD-220] EngOps Account Building worker node AMI for 1.20

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,9 +3,9 @@
 @Library('OGJenkinsLib@3.18.0') _
 
 final GIT_REPOSITORY_NAME = 'amazon-eks-ami'
-final KUBERNETES_VERSION = '1.19.8'
+final KUBERNETES_VERSION = '1.20.10'
 final PACKER_IMAGE_MANIFEST = 'manifest.json'
-final OG_IMAGE_VERSION = '1.6.0'
+final OG_IMAGE_VERSION = '1.7.0'
 def config = [:]  // Pipeline configuration
 
 def containers = [

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ PACKER_VARIABLES := aws_region ami_name binary_bucket_name binary_bucket_region 
 
 K8S_VERSION_PARTS := $(subst ., ,$(kubernetes_version))
 K8S_VERSION_MINOR := $(word 1,${K8S_VERSION_PARTS}).$(word 2,${K8S_VERSION_PARTS})
-kubernetes_build_date ?= 2021-05-13
+kubernetes_build_date ?= 2021-10-12
 aws_region ?= $(AWS_DEFAULT_REGION)
 binary_bucket_region ?= $(AWS_DEFAULT_REGION)
 ami_name ?= og-amazon-eks-node-$(K8S_VERSION_MINOR)-v$(shell date +'%Y%m%d%H%M%S')
@@ -28,7 +28,7 @@ T_YELLOW := \e[0;33m
 T_RESET := \e[0m
 
 .PHONY: all
-all: 1.16 1.17 1.18 1.19
+all: 1.17 1.18 1.19 1.20
 
 .PHONY: validate
 validate:
@@ -57,3 +57,7 @@ k8s: validate
 .PHONY: 1.19
 1.18:
 	$(MAKE) k8s kubernetes_version=1.19.8 kubernetes_build_date=2021-05-13 pull_cni_from_github=true
+
+PHONY: 1.20
+1.20:
+	$(MAKE) k8s kubernetes_version=1.20.10 kubernetes_build_date=2021-10-12 pull_cni_from_github=true

--- a/OG-CHANGELOG.md
+++ b/OG-CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+1.5.6 - 10/19/2021
+-----------------------
+- Updated latest build date for 1.20.10 to `2021-10-12`
+- Updated K8s version to `1.20.10`
+
 1.5.5 - 07/29/2021
 -----------------------
 - Updated latest build date for 1.18.16 to `2021-05-13`

--- a/eks-worker-al2.json
+++ b/eks-worker-al2.json
@@ -16,7 +16,7 @@
     "kubernetes_build_date": null,
     "docker_version": "19.03.6ce-4.amzn2",
     "cni_plugin_version": "v0.8.6",
-    "og_image_version": "1.5.0",
+    "og_image_version": "1.7.0",
     "ami_regions": "us-west-2,us-east-1",
     "pull_cni_from_github": "true",
 


### PR DESCRIPTION
*Issue #, if available:* https://opengovinc.atlassian.net/browse/CLOUD-220

*Description of changes:* Updated JenkinsFile, MakeFile, Changelog.md and eks-worker-al2.json to add 1.20 version


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
